### PR TITLE
xkeysym version 0.2.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xkeysym"
-version = "0.1.1"
+version = "0.2.0"
 edition = "2018"
 authors = ["John Nunley <jtnunley01@gmail.com>"]
 description = "A library for working with X11 keysyms"


### PR DESCRIPTION
--
Will wait for #11, so the crate could at least be used by distros if they want to.