### PR TITLE
Avoid panicking if keysym() was called with a keycode larger than max_keycode

### DIFF
--- a/examples/x11rb.rs
+++ b/examples/x11rb.rs
@@ -119,6 +119,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                     keycode.into(),
                     0,
                     conn.setup().min_keycode.into(),
+                    conn.setup().max_keycode.into(),
                     mapping.keysyms_per_keycode,
                     mapping.keysyms.as_slice(),
                 );

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -287,16 +287,17 @@ pub const NO_SYMBOL: Keysym = Keysym(0);
 
 /// Get the keyboard symbol from a keyboard code and its column.
 ///
-/// `min_keycode` can be retrieved from the X11 setup, and `keysyms_per_keycode` and `keysyms` can be
+/// `min_keycode` and `max_keycode` can be retrieved from the X11 setup, and `keysyms_per_keycode` and `keysyms` can be
 /// retrieved from the X11 server through the `GetKeyboardMapping` request.
 pub fn keysym(
     keycode: KeyCode,
     mut column: u8,
     min_keycode: KeyCode,
+    max_keycode: KeyCode,
     keysyms_per_keycode: u8,
     keysyms: &[RawKeysym],
 ) -> Option<Keysym> {
-    if column >= keysyms_per_keycode && column > 3 {
+    if column >= keysyms_per_keycode && column > 3 || keycode > max_keycode {
         return None;
     }
 


### PR DESCRIPTION
Currently the `keysym` function panics if the provided keycode was too large. The original `KeyCodetoKeySym` function also checks if the keycode is small enough ([source](https://github.com/mirror/libX11/blob/ff8706a5eae25b8bafce300527079f68a201d27f/src/KeyBind.c#L93)).

My PR fixes this through a breaking change and asking for the `max_keycode` in addition to the `min_keycode`. The value should already be obtained during the X11 setup.

An alternative is to calculate the `max_keycode` each time. It has the benefit that we would not rely on the value for `max_keycode` to be correct. On the other hand, the type conversions make the check a bit awkward and it probably is not needed to recalculate it each time. Calculating the value each time could look something like this:

```
let Ok(max_keycode) =
    core::convert::TryInto::try_into(keysyms.len() / (usize::from(keysyms_per_keycode)))
else {
    return None;
};
if column >= keysyms_per_keycode && column > 3 || keycode.0 > max_keycode {
    return None;
}
```
