### PR TITLE
Improve GitHub actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,14 @@
+version: 2
+updates:
+
+  # Maintain dependencies for GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+
+  # Maintain dependencies for cargo
+  - package-ecosystem: "cargo"
+    directory: "/"
+    schedule:
+      interval: "daily"

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -18,93 +18,63 @@
 
 name: CI
 
+permissions:
+  contents: read
 on:
   push:
     branches:
       - master
   pull_request:
+  workflow_dispatch:
 
 env:
   RUSTFLAGS: -Dwarnings
-  clippy_version: 1.60.0
+  CARGO_TERM_COLOR: always
 
 jobs:
-  rustfmt:
-    name: rustfmt
+  CI:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
-        include:
-          - rust: stable
+        rust:
+          - stable
+          - beta
+          - nightly
+          - 1.48.0
     
-    steps:
-      - uses: actions/checkout@v3
-      - name: Install Rust
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: ${{ matrix.rust }}
-          profile: minimal
-          override: true
-          components: rustfmt
-      - uses: Swatinem/rust-cache@v1
-      - name: Run rustfmt
-        run: cargo fmt --check
-   
-  clippy:
-    name: clippy
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: actions/checkout@v3
-      - name: Install Rust
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: ${{ env.clippy_version }}
-          override: true
-          components: clippy
-      - uses: Swatinem/rust-cache@v1
-      - name: Run Clippy
-        uses: actions-rs/cargo@v1
-        with:
-          command: clippy
-          args: --all --tests --all-features
-
-  test:
-    runs-on: ubuntu-latest 
-    strategy:
-      matrix:
-        toolchain:
-         - stable
-         - beta
-         - nightly
-
     steps:
       - uses: actions/checkout@v3
         with:
           submodules: true
       - name: Install Rust
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: ${{ matrix.toolchain }}
-          override: true
+          toolchain: ${{ matrix.rust }}
+          components: rustfmt, clippy
       - uses: Swatinem/rust-cache@v1
-
-      - name: Test
+      - name: Run rustfmt
+        if: matrix.rust == 'stable' # Avoid differences between the versions
+        run: cargo fmt --check
+      - name: Run Clippy
+        if: matrix.rust == 'stable' # Avoid differences between the versions
+        run: cargo clippy --all-features
+      - name: Check clippy lints for the examples
+        if: matrix.rust == 'stable' # Avoid differences between the versions
+        run: cargo clippy --all-features --examples
+      - name: Check clippy lints for the tests
+        if: matrix.rust == 'stable' # Avoid differences between the versions
+        run: cargo clippy --all-features --tests
+      - name: Build the crate
+        run: cargo build --all-features
+      - name: Build the examples
+        run: cargo build --all-features --examples
+      - name: Run the tests
         run: cargo test
+      - name: Run the tests with all features enabled
+        run: cargo test --all-features
+      - name: Build the docs
+        run: cargo doc
+      - name: Build the docs with all features enabled
+        run: cargo doc --all-features
 
-  msrv:
-    name: Build MSRV
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: actions/checkout@v3
-      - name: Install Rust
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: 1.48.0
-          override: true
-      - uses: Swatinem/rust-cache@v1
-      - name: Build
-        run: cargo build
-      
-  

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -41,7 +41,7 @@ jobs:
           - stable
           - beta
           - nightly
-          - 1.48.0
+          - 1.58.1
     
     steps:
       - uses: actions/checkout@v3

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ description = "A library for working with X11 keysyms"
 repository = "https://github.com/notgull/xkeysym"
 license = "MIT OR Apache-2.0 OR Zlib"
 keywords = ["x11", "keysym", "keysyms"]
-rust-version = "1.48.0"
+rust-version = "1.58.1"
 
 [dev-dependencies]
 bytemuck = "1.12.3"

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ In addition, this crate contains no unsafe code and is fully compatible with
 
 ## MSRV Policy
 
-The Minimum Safe Rust Version for this crate is **1.48.0**.
+The Minimum Safe Rust Version for this crate is **1.58.1**.
 
 ## License
 


### PR DESCRIPTION
This PR improves the Github Action in a couple of ways:

- Fixed failed clippy action
- actions-rs/toolchain was [unmaintained](https://github.com/actions-rs/toolchain/issues/216) and the repo has been archived. It was replaced with dtolnay/rust-toolchain, which seems like the new standard action
-  Restricted the [permissions](https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs#setting-the-github_token-permissions-for-all-jobs-in-a-workflow) of the Github Token used by the Action
- Added dependabot to keep the dependencies of the crate updated and additionally check the versions of the actions used in the Github Workflow
- Allow manually triggering the workflow
- Check the clippy lints for the crate, the examples and the tests
- Make sure the crate builds on the MSRV, stable, nightly and beta
- Make sure the docs build