### PR TITLE
Use a docker container for generating keysyms

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -32,6 +32,22 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
+  codegen:
+    name: codegen
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: just@1.15.0
+      - name: Run codegen
+        run: just
+      - name: Check for git changes
+        run: if ! git diff --exit-code; then exit 1; fi
+
   CI:
     runs-on: ubuntu-latest
     strategy:

--- a/Justfile
+++ b/Justfile
@@ -20,8 +20,8 @@ keysyms:
     docker container run --rm \
         --name keysym_generator \
         --mount type=bind,source="$(pwd)",target=/xkeysym \
-        -it rust:slim-bookworm \
-        sh -c "apt-get update && apt-get install x11proto-core-dev && \
+        -it rust:slim \
+        sh -c "apt-get update -y && apt-get install x11proto-core-dev -y --no-install-recommends && \
         cargo run --manifest-path /xkeysym/keysym-generator/Cargo.toml \
            /xkeysym/src/automatically_generated.rs"
 

--- a/Justfile
+++ b/Justfile
@@ -17,5 +17,11 @@
 # limitations under the Licenses.
 
 keysyms:
-    cargo run --manifest-path keysym-generator/Cargo.toml \
-        src/automatically_generated.rs
+    docker container run --rm \
+        --name keysym_generator \
+        --mount type=bind,source="$(pwd)",target=/xkeysym \
+        -it rust:slim-bookworm \
+        sh -c "apt-get update && apt-get install x11proto-core-dev && \
+        cargo run --manifest-path /xkeysym/keysym-generator/Cargo.toml \
+           /xkeysym/src/automatically_generated.rs"
+

--- a/Justfile
+++ b/Justfile
@@ -20,7 +20,7 @@ keysyms:
     docker container run --rm \
         --name keysym_generator \
         --mount type=bind,source="$(pwd)",target=/xkeysym \
-        -it rust:slim \
+        rust:slim \
         sh -c "apt-get update -y && apt-get install x11proto-core-dev -y --no-install-recommends && \
         cargo run --manifest-path /xkeysym/keysym-generator/Cargo.toml \
            /xkeysym/src/automatically_generated.rs"

--- a/README.md
+++ b/README.md
@@ -13,6 +13,15 @@ In addition, this crate contains no unsafe code and is fully compatible with
 
 The Minimum Safe Rust Version for this crate is **1.58.1**.
 
+## Updating Headers
+
+To update the automatically generated keyboard symbols in the
+`automatically_generated.rs` file, install [Just] and run `just`. The process
+creates a Debian Docker container in order to keep the files consistent, so make
+sure Docker is installed first.
+
+[Just]: https://github.com/casey/just
+
 ## License
 
 Licensed under either of


### PR DESCRIPTION
Previously, keysyms were just generated on the host operating system. This means that the keysyms that are generated varies from system to system, which is just bad form. This commit makes it so the keysyms are generated inside of a Docker container, which should make the process much more reproducible.