### PR TITLE
v0.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,4 @@
+# v0.2.1
+
+- Add new keysyms from xorgproto 2024.1. (#29)
+- Add Keysym::NoSymbol. This is an alias for the "NO_SYMBOL" constant. (#17)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xkeysym"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2018"
 authors = ["John Nunley <jtnunley01@gmail.com>"]
 description = "A library for working with X11 keysyms"


### PR DESCRIPTION
- Add new keysyms from xorgproto 2024.1. (#29)
- Add Keysym::NoSymbol. This is an alias for the "NO_SYMBOL" constant. (#17)
