### PR TITLE
Align the debug output with what libxkbcommon does

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -111,6 +111,12 @@ impl fmt::Debug for Keysym {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self.name() {
             Some(name) => f.write_str(name),
+            None if (0x0100_0100..=0x0110_FFFF).contains(&self.0) => {
+                // strip the 0x01000000 prefix
+                let codepoint = self.0 & 0x00FF_FFFF;
+                // Uppercase hex, no leading zeros: e.g. "UA1B2"
+                write!(f, "U{:X}", codepoint)
+            }
             None => write!(f, "{:#x}", self.0),
         }
     }


### PR DESCRIPTION
The documentation of libxkbcommon says: "Any Unicode/ISO 10646 character in the range U+0100 to U+10FFFF can be represented by a keysym value in the range 0x01000100 to 0x0110FFFF. The name of Unicode keysyms is U<codepoint>, e.g. UA1B2. The name of other unnamed keysyms is the hexadecimal representation of their value, e.g. 0xabcd1234"